### PR TITLE
fix up some not-very-serious compiler warnings

### DIFF
--- a/src/SparkFunDS3234RTC.cpp
+++ b/src/SparkFunDS3234RTC.cpp
@@ -161,7 +161,7 @@ void DS3234::autoTime()
 	
 	_time[TIME_MONTH] = DECtoBCD(BUILD_MONTH);
 	_time[TIME_DATE] = DECtoBCD(BUILD_DATE);
-    //! Not Y2K (or Y2.1K)-proof :
+        //! Not Y2K (or Y2.1K)-proof :
 	_time[TIME_YEAR] = DECtoBCD(BUILD_YEAR - 2000); 
 	
 	// Calculate weekday (from here: http://stackoverflow.com/a/21235587)

--- a/src/SparkFunDS3234RTC.cpp
+++ b/src/SparkFunDS3234RTC.cpp
@@ -130,7 +130,7 @@ void DS3234::setTime(uint8_t * time, uint8_t len)
 }
 
 // autoTime -- Fill DS3234 time registers with compiler time/date
-bool DS3234::autoTime()
+void DS3234::autoTime()
 {
 	_time[TIME_SECONDS] = DECtoBCD(BUILD_SECOND);
 	_time[TIME_MINUTES] = DECtoBCD(BUILD_MINUTE);
@@ -161,7 +161,8 @@ bool DS3234::autoTime()
 	
 	_time[TIME_MONTH] = DECtoBCD(BUILD_MONTH);
 	_time[TIME_DATE] = DECtoBCD(BUILD_DATE);
-	_time[TIME_YEAR] = DECtoBCD(BUILD_YEAR - 2000); //! Not Y2K (or Y2.1K)-proof :\
+    //! Not Y2K (or Y2.1K)-proof :
+	_time[TIME_YEAR] = DECtoBCD(BUILD_YEAR - 2000); 
 	
 	// Calculate weekday (from here: http://stackoverflow.com/a/21235587)
 	// Result: 0 = Sunday, 6 = Saturday
@@ -671,7 +672,6 @@ uint8_t DS3234::spiReadByte(DS3234_registers reg)
 // spiWriteBytes -- read a set number of bytes from an spi device, incrementing from a register
 void DS3234::spiReadBytes(DS3234_registers reg, uint8_t * dest, uint8_t len)
 {
-	uint8_t retVal = 0;
 	SPI.beginTransaction(DS3234SPISettings);
 	digitalWrite(_csPin, LOW);
 	SPI.transfer(reg);

--- a/src/SparkFunDS3234RTC.h
+++ b/src/SparkFunDS3234RTC.h
@@ -128,7 +128,7 @@ public:
 	// setTime -- Set time and date/day registers of DS3234 (using data array)
 	void setTime(uint8_t * time, uint8_t len);
 	// autoTime -- Set time with compiler time/date
-	bool autoTime();
+	void autoTime();
 	
 	// To set specific values of the clock, use the set____ functions:
 	void setSecond(uint8_t s);


### PR DESCRIPTION
```
lib/SparkFun_DS3234_RTC_Arduino_Library/src/SparkFunDS3234RTC.cpp:164:50: warning: multi-line comment [-Wcomment]
_time[TIME_YEAR] = DECtoBCD(BUILD_YEAR - 2000); //! Not Y2K (or Y2.1K)-proof :\
^
lib/SparkFun_DS3234_RTC_Arduino_Library/src/SparkFunDS3234RTC.cpp: In member function 'bool DS3234::autoTime()':
lib/SparkFun_DS3234_RTC_Arduino_Library/src/SparkFunDS3234RTC.cpp:177:1: warning: no return statement in function returning non-void [-Wreturn-type]
}
^
lib/SparkFun_DS3234_RTC_Arduino_Library/src/SparkFunDS3234RTC.cpp: In member function 'void DS3234::spiReadBytes(DS3234_registers, uint8_t*, uint8_t)':
lib/SparkFun_DS3234_RTC_Arduino_Library/src/SparkFunDS3234RTC.cpp:674:10: warning: unused variable 'retVal' [-Wunused-variable]
uint8_t retVal = 0;
^
```

just a minor clean-up