### PR TITLE
enable writeToSRAM()/readFromSRAM to directly handle other data types than bytes

### DIFF
--- a/examples/DS3234_RTC_SRAM_Demo/DS3234_RTC_SRAM_Demo.ino
+++ b/examples/DS3234_RTC_SRAM_Demo/DS3234_RTC_SRAM_Demo.ino
@@ -125,6 +125,94 @@ void setup()  {
   }
   Serial.println();
 
+  /* Write and read other data types directly to/from SRAM */
+
+  // If you want to store some other data types than bytes or collection of bytes
+  // into SRAM, you can use the "templated" versions of writeToSRAM() and readFromSRAM().
+  // If you don't know about C++ templates and you are curious, you can read up on them
+  // on Wikipedia: https://en.wikipedia.org/wiki/Template_(C%2B%2B).
+  // However, understanding how it works under the hood is by no means necessary! :-)
+
+  // Warning 1:
+  // writeToSRAM() readFromSRAM() do *not* take byte-ordering (i.e. "endian-ness") into
+  // account. If you want to write data to SRAM of the DS3234 one one type of micro
+  // controller, unplug it, re-plug it to another type of micro controller, you have to
+  // make sure that both types of MC work with the same byte ordering, otherwise you might
+  // get garbage. If you never move your RTC from one type of MCU to another type, you are
+  // safe.
+  // You can read more about endianness on Wikipedia: https://en.wikipedia.org/wiki/Endianness
+
+  // Warning 2:
+  // The data type "double" is an alias for "float" (IEEE 754 single precision floating point 
+  // number with 32 bit width) on some Arduinos, and a "real double" (i.e. a IEEE 754 double 
+  // precision floating point number with 64 bit width) on others. Even when mixing Arduinos
+  // with the same endianness, this might lead to data corruption. Again, this is ONLY a problem
+  // when plugging your RTC to another type of Arduino. So, not a problem at all most of the time.
+  // Just trying to be honest here... ;-)
+  
+  // Example 1: Store and read a uint16_t
+  uint16_t uint16_data = 32769;
+
+  // write uint16_t to SRAM
+  Serial.print(F("Writing a uint16_t with value "));
+  Serial.print(uint16_data, DEC);
+  Serial.print(F(" to memory address 0x"));
+  Serial.print(sram_address, HEX);
+  Serial.print(F("."));
+  Serial.println(); 
+  
+  // Note the angled brackets after the function! They tell the compiler which data
+  // type you want to instantiate the template for.
+  rtc.writeToSRAM<uint16_t>(sram_address, uint16_data);
+
+  // And now read the value back:
+  uint16_t read_back_uint16 = rtc.readFromSRAM<uint16_t>(sram_address);
+
+  Serial.print(F("We have read back a uint16_t with value "));
+  Serial.print(read_back_uint16, DEC);
+  Serial.print(F(" from memory address 0x"));
+  Serial.print(sram_address, HEX);
+  Serial.print(F("."));
+  Serial.println();
+
+  Serial.print(F("Written and read uint16_t values are equal: "));
+  if (uint16_data == read_back_uint16) {
+    Serial.println(F("true"));
+  }
+  else {
+    Serial.println(F("false"));    
+  }
+
+  // Example 2: Using a signed integer this time
+  // (skipping most of the Serial.print() stuff...)
+  int32_t int32_data = -128653;
+  rtc.writeToSRAM<int32_t>(sram_address, int32_data);
+
+  int32_t read_back_int32 = rtc.readFromSRAM<int32_t>(sram_address);
+
+  Serial.print(F("Written and read int32_t values are equal: "));
+  if (int32_data == read_back_int32) {
+    Serial.println(F("true"));
+  }
+  else {
+    Serial.println(F("false"));    
+  }
+  
+  // Example 3: Using a floating point
+  // (skipping most of the Serial.print() stuff...)
+  float float_data = 3.14159265358979; // the number pi
+  rtc.writeToSRAM<float>(sram_address, float_data);
+
+  float read_back_float = rtc.readFromSRAM<float>(sram_address);
+
+  Serial.print(F("Written and read float values are equal: "));
+  if (float_data == read_back_float) {
+    Serial.println(F("true"));
+  }
+  else {
+    Serial.println(F("false"));    
+  }
+
   Serial.println(F("\n### DS3242_RTC_SRAM_Demo finished! ###\n"));
 
 } // end of setup(), end of demo

--- a/examples/DS3234_RTC_SRAM_Demo/DS3234_RTC_SRAM_Demo.ino
+++ b/examples/DS3234_RTC_SRAM_Demo/DS3234_RTC_SRAM_Demo.ino
@@ -133,6 +133,11 @@ void setup()  {
   // on Wikipedia: https://en.wikipedia.org/wiki/Template_(C%2B%2B).
   // However, understanding how it works under the hood is by no means necessary! :-)
 
+  // Note:
+  // *You* are responsible for non-overlapping memory ranges. If you write some data type with
+  // a width of, say, four byte to SRAM address x, the next value to store can start at SRAM
+  // address x+4 (because locatons x, x+1, x+2 and x+3 are already in use). 
+
   // Warning 1:
   // writeToSRAM() readFromSRAM() do *not* take byte-ordering (i.e. "endian-ness") into
   // account. If you want to write data to SRAM of the DS3234 one one type of micro

--- a/src/SparkFunDS3234RTC.cpp
+++ b/src/SparkFunDS3234RTC.cpp
@@ -700,6 +700,27 @@ void DS3234::writeToSRAM(uint8_t address, uint8_t* values, size_t len)
 	spiWriteBytes(DS3234_REGISTER_SRAMD, values, len);
 }
 
+template <typename T>
+void DS3234::writeToSRAM(uint8_t address, T value)
+{
+	uint8_t buf[sizeof(T)];
+	memcpy(buf, &value, sizeof(T));
+	writeToSRAM(address, buf, sizeof(T));
+}
+
+// explicit instantiations for writeToSRAM() template
+// Otherwise we would have to implement the templated writeToSRAM() 
+// function in the header file.
+template void DS3234::writeToSRAM<uint16_t>(uint8_t, uint16_t);
+template void DS3234::writeToSRAM<uint32_t>(uint8_t, uint32_t);
+template void DS3234::writeToSRAM<uint64_t>(uint8_t, uint64_t);
+template void DS3234::writeToSRAM<int8_t>(  uint8_t, int8_t);
+template void DS3234::writeToSRAM<int16_t>( uint8_t, int16_t);
+template void DS3234::writeToSRAM<int32_t>( uint8_t, int32_t);
+template void DS3234::writeToSRAM<int64_t>( uint8_t, int64_t);
+template void DS3234::writeToSRAM<float>(   uint8_t, float);
+template void DS3234::writeToSRAM<double>(  uint8_t, double);
+
 uint8_t DS3234::readFromSRAM(uint8_t address)
 {
 	spiWriteByte(DS3234_REGISTER_SRAMA, address);
@@ -712,6 +733,28 @@ void DS3234::readFromSRAM(uint8_t address, uint8_t* dest, size_t len)
 	spiReadBytes(DS3234_REGISTER_SRAMD, dest, len);
 }
 
+template <typename T>
+T DS3234::readFromSRAM(uint8_t address)
+{
+	uint8_t buf[sizeof(T)];
+	T value;
+	readFromSRAM(address, buf, sizeof(T));
+	memcpy(&value, buf, sizeof(T));
+	return value;
+}
+
+// explicit instantiations for readFromSRAM() template
+// Otherwise we would have to implement the templated readFromSRAM() 
+// function in the header file.
+template uint16_t DS3234::readFromSRAM<uint16_t>(uint8_t);
+template uint32_t DS3234::readFromSRAM<uint32_t>(uint8_t);
+template uint64_t DS3234::readFromSRAM<uint64_t>(uint8_t);
+template int8_t   DS3234::readFromSRAM<int8_t>(  uint8_t);
+template int16_t  DS3234::readFromSRAM<int16_t>( uint8_t);
+template int32_t  DS3234::readFromSRAM<int32_t>( uint8_t);
+template int64_t  DS3234::readFromSRAM<int64_t>( uint8_t);
+template float    DS3234::readFromSRAM<float>(   uint8_t);
+template double   DS3234::readFromSRAM<double>(  uint8_t);
 
 void DS3234::writeToRegister(uint8_t address, uint8_t data)
 {

--- a/src/SparkFunDS3234RTC.h
+++ b/src/SparkFunDS3234RTC.h
@@ -219,9 +219,11 @@ public:
 
 	void writeToSRAM(uint8_t address, uint8_t data);
 	void writeToSRAM(uint8_t address, uint8_t *values, size_t len);
+	template <typename T> void writeToSRAM(uint8_t address, T value);
 
 	uint8_t readFromSRAM(uint8_t address);
 	void readFromSRAM(uint8_t address, uint8_t *dest, size_t len);
+	template <typename T> T readFromSRAM(uint8_t address);
 
 	void writeToRegister(uint8_t address, uint8_t data);
 	uint8_t readFromRegister(uint8_t address);


### PR DESCRIPTION
Hi Nathan (@nseidle),

as mentioned earlier today (see https://github.com/sparkfun/SparkFun_DS3234_RTC_Arduino_Library/pull/13#issuecomment-964005583), I have another suggestion for new functionality with respect to `writeToSRAM()` and `readToSRAM`.

With this pull request, templated overloads are added to the library. Using those, one can directly store signed and unsigned integers and floating point numbers in SRAM and retrieve them again. The complete list of implemented data types:
* `uint16_t`
* `uint32_t`
* `uint64_t`
* `int8_t`
* `int16_t`
* `int32_t`
* `int64_t`
* `float`
* `double`

To explain stuff, I added examples and extensive comments to the SRAM demo sketch.

I would be glad if you considered this pull request for merging.

Yours
Andreas